### PR TITLE
Fixes

### DIFF
--- a/StateMachineBehaviours/AnimatorEvent.cs
+++ b/StateMachineBehaviours/AnimatorEvent.cs
@@ -21,6 +21,8 @@ public class AnimatorEvent : MonoBehaviour {
 	// This will prevent be one frame ahead, with the character's old pose from the previous animation
 	private Queue<string>[] queuedEvents = new Queue<string>[5];
 
+	public bool debug = false;
+
 	void Awake() {
 		for (int i = 0; i < queuedEvents.Length; i++) {
 			queuedEvents[i] = new Queue<string>();
@@ -28,10 +30,19 @@ public class AnimatorEvent : MonoBehaviour {
 		foreach (var elem in events) {
 			elementsDict.Add(elem.name, elem);
 		}
+
+		// Initialize references in SMBs
+		foreach (var smb in GetComponent<Animator>().GetBehaviours<AnimatorEventSMB>()) {
+			smb.SetAnimatorEvent(this);
+		}
 	}
 
 	public void Event(string name, EventType eventType) {
-		//Debug.Log("Event " + eventType + ": " + name);
+#if UNITY_EDITOR
+		if (debug) {
+			Debug.Log("Event [" + eventType + "]: " + name);
+		}
+#endif
 
 		EventElement e;
 		if (elementsDict.TryGetValue(name, out e)) {

--- a/StateMachineBehaviours/AnimatorEventSMB.cs
+++ b/StateMachineBehaviours/AnimatorEventSMB.cs
@@ -13,7 +13,7 @@ public class AnimatorEventSMB : StateMachineBehaviourExtended {
 	public TimedEvent[] onNormalizedTimeReached;
 	public TimedEvent[] onStateUpdated; // onStateUpdated instead of onStateUpdate because of a naming error. In the future it can be changed to onStateUpdate
 
-	private AnimatorEvent animatorEvent;
+	private AnimatorEvent animatorEvent; // Initialized by AnimatorEvent.Awake
 
 	[Serializable]
 	public struct TimedEvent {
@@ -28,7 +28,6 @@ public class AnimatorEventSMB : StateMachineBehaviourExtended {
 
 	public override void StateEnter_TransitionStarts(Animator animator, AnimatorStateInfo stateInfo, int layerIndex) {
 		//Debug.Log("[" + state.fullPathHash + "] (" + stateInfo.fullPathHash + ") OnStateEnter_TransitionStarts");
-		if (animatorEvent == null) animatorEvent = animator.GetComponent<AnimatorEvent>();
 		FireTimedEvents(onStateEnterTransitionStart, AnimatorEvent.EventType.OnEnterTransitionStart);
 	}
 
@@ -49,7 +48,7 @@ public class AnimatorEventSMB : StateMachineBehaviourExtended {
 		// Finalize events that want to execute on end, and reset them for later
 		for (int i = 0; i < onNormalizedTimeReached.Length; i++) {
 			if (onNormalizedTimeReached[i].executeOnExitEnds && onNormalizedTimeReached[i].nextNormalizedTime == 0) {
-				animatorEvent.Event(onNormalizedTimeReached[i].callback, AnimatorEvent.EventType.OnUpdate);
+				animatorEvent.Event(onNormalizedTimeReached[i].callback, AnimatorEvent.EventType.OnExitTransitionEnd);
 			}
 			onNormalizedTimeReached[i].nextNormalizedTime = 0;
 		}
@@ -68,6 +67,10 @@ public class AnimatorEventSMB : StateMachineBehaviourExtended {
 					onNormalizedTimeReached[i].nextNormalizedTime = int.MaxValue;
 			}
 		}
+	}
+
+	public void SetAnimatorEvent(AnimatorEvent animatorEvent) {
+		this.animatorEvent = animatorEvent;
 	}
 
 	private void FireTimedEvents(TimedEvent[] events, AnimatorEvent.EventType eventType) {

--- a/StateMachineBehaviours/Editor/AnimatorEventSMBEditor.cs
+++ b/StateMachineBehaviours/Editor/AnimatorEventSMBEditor.cs
@@ -21,6 +21,12 @@ public class AnimatorEventSMBEditor : Editor {
 	private StateMachineBehaviourContext[] contexts;
 
 	private void OnEnable() {
+		// accessing serializedObject after reloading scripts can throw an exception. There is no way around it, so just ignore it
+		try {
+			var s = serializedObject;
+		}
+		catch (System.Exception) { return; }
+
 		CreateReorderableList("On State Enter Transition Start", 20, ref list_onStateEnterTransitionStart, serializedObject.FindProperty("onStateEnterTransitionStart"),
 			(rect, index, isActive, isFocused) => {
 				DrawCallbackField(rect, serializedObject.FindProperty("onStateEnterTransitionStart").GetArrayElementAtIndex(index));


### PR DESCRIPTION
- Fix exception on editors of StateMachineBehaviour that call OnEnable in a moment that calling serializedObject throws an exception
- Fix wrong execution order of the event onNormalizedTimeReached when called thanks to executeOnExitEnds (OnUpdate => OnExitTransitionEnd)
- Fix if the first state played in an Animator uses evens in Update or exit, it is not initialized yet and throws exceptions